### PR TITLE
feat: tick-tock

### DIFF
--- a/docs/tick-tock-plan.md
+++ b/docs/tick-tock-plan.md
@@ -1,0 +1,17 @@
+# Tick-Tock Countdown Sound Plan
+
+1. **Configuration**
+   - Add a new boolean setting `CLOCK_TICK_SOUND` with default `FALSE`.
+   - Provide a function `WriteConfigTickSound` to persist the setting.
+   - Read and write the value in the config file, including default generation and generic key writer.
+
+2. **User Interface**
+   - Introduce a menu item to toggle the tick‑tock sound. The menu reflects the current state and stores changes via `WriteConfigTickSound`.
+
+3. **Timer Behaviour**
+   - When the setting is enabled and the countdown is running, play a tick‑tock beep every second using `Beep` with alternating frequencies.
+   - Ensure no sound plays once the countdown finishes or in count‑up/current‑time modes.
+
+4. **Integration**
+   - Wire the new toggle into existing configuration loading and saving paths.
+   - Update build tests to ensure the project still compiles.

--- a/include/config.h
+++ b/include/config.h
@@ -120,6 +120,9 @@ extern TimeFormatType PREVIEW_TIME_FORMAT;
 /** @brief Centiseconds display setting (2-digit precision) */
 extern BOOL CLOCK_SHOW_MILLISECONDS;
 
+/** @brief Tick-tock countdown sound enabled flag */
+extern BOOL CLOCK_TICK_SOUND;
+
 /** @brief Centiseconds preview variables */
 extern BOOL IS_MILLISECONDS_PREVIEWING;
 extern BOOL PREVIEW_SHOW_MILLISECONDS;
@@ -492,6 +495,12 @@ void WriteConfigTimeFormat(TimeFormatType format);
  * @param showMilliseconds TRUE to show milliseconds, FALSE to hide
  */
 void WriteConfigShowMilliseconds(BOOL showMilliseconds);
+
+/**
+ * @brief Write tick-tock sound setting to config file
+ * @param enable TRUE to enable tick sound, FALSE to disable
+ */
+void WriteConfigTickSound(BOOL enable);
 
 /**
  * @brief Get appropriate timer interval based on milliseconds display setting

--- a/include/tray_menu.h
+++ b/include/tray_menu.h
@@ -45,6 +45,7 @@
 #define CLOCK_IDM_TIME_FORMAT_ZERO_PADDED 196   /**< Zero-padded format 09:59 */
 #define CLOCK_IDM_TIME_FORMAT_FULL_PADDED 197   /**< Full zero-padded format 00:09:59 */
 #define CLOCK_IDM_TIME_FORMAT_SHOW_MILLISECONDS 198   /**< Show milliseconds in time format */
+#define CLOCK_IDM_TICK_SOUND 189              /**< Toggle tick-tock sound */
 
 /** @brief Startup configuration */
 #define CLOCK_IDC_SET_COUNTDOWN_TIME 173   /**< Set default countdown time */

--- a/resource/resource.h
+++ b/resource/resource.h
@@ -128,6 +128,7 @@
 #define CLOCK_IDM_COUNT_UP_RESET 172     /**< Reset count-up timer */
 #define CLOCK_IDM_COUNTDOWN_START_PAUSE 154  /**< Start/pause countdown timer */
 #define CLOCK_IDM_COUNTDOWN_RESET 155    /**< Reset countdown timer */
+#define CLOCK_IDM_TICK_SOUND 189         /**< Toggle tick-tock sound */
 
 /** @brief Startup configuration control identifiers */
 #define CLOCK_IDC_SET_COUNTDOWN_TIME 173 /**< Set countdown time control */

--- a/src/config.c
+++ b/src/config.c
@@ -62,6 +62,9 @@ TimeFormatType PREVIEW_TIME_FORMAT = TIME_FORMAT_DEFAULT;
 /** @brief Milliseconds display setting */
 BOOL CLOCK_SHOW_MILLISECONDS = FALSE;
 
+/** @brief Tick-tock countdown sound setting */
+BOOL CLOCK_TICK_SOUND = FALSE;
+
 /** @brief Milliseconds preview variables */
 BOOL IS_MILLISECONDS_PREVIEWING = FALSE;
 BOOL PREVIEW_SHOW_MILLISECONDS = FALSE;
@@ -367,6 +370,7 @@ void CreateDefaultConfig(const char* config_path) {
     WriteIniString(INI_SECTION_TIMER, "CLOCK_SHOW_SECONDS", "FALSE", config_path);
     WriteIniString(INI_SECTION_TIMER, "CLOCK_TIME_FORMAT", "DEFAULT", config_path);
     WriteIniString(INI_SECTION_TIMER, "CLOCK_SHOW_MILLISECONDS", "FALSE", config_path);
+    WriteIniString(INI_SECTION_TIMER, "CLOCK_TICK_SOUND", "FALSE", config_path);
     WriteIniString(INI_SECTION_TIMER, "CLOCK_TIME_OPTIONS", "1500,600,300", config_path);
     WriteIniString(INI_SECTION_TIMER, "CLOCK_TIMEOUT_TEXT", "0", config_path);
     WriteIniString(INI_SECTION_TIMER, "CLOCK_TIMEOUT_ACTION", "MESSAGE", config_path);
@@ -668,6 +672,9 @@ void ReadConfig() {
     
     /** Load milliseconds display setting */
     CLOCK_SHOW_MILLISECONDS = ReadIniBool(INI_SECTION_TIMER, "CLOCK_SHOW_MILLISECONDS", FALSE, config_path);
+
+    /** Load tick-tock sound setting */
+    CLOCK_TICK_SOUND = ReadIniBool(INI_SECTION_TIMER, "CLOCK_TICK_SOUND", FALSE, config_path);
     
     /** Parse language string to enum value */
     int languageSetting = APP_LANG_ENGLISH;
@@ -1777,6 +1784,7 @@ void WriteConfig(const char* config_path) {
     }
     WriteIniString(INI_SECTION_TIMER, "CLOCK_TIME_FORMAT", timeFormatStr, config_path);
     WriteIniString(INI_SECTION_TIMER, "CLOCK_SHOW_MILLISECONDS", CLOCK_SHOW_MILLISECONDS ? "TRUE" : "FALSE", config_path);
+    WriteIniString(INI_SECTION_TIMER, "CLOCK_TICK_SOUND", CLOCK_TICK_SOUND ? "TRUE" : "FALSE", config_path);
     WriteIniString(INI_SECTION_TIMER, "CLOCK_TIMEOUT_TEXT", CLOCK_TIMEOUT_TEXT, config_path);
     WriteIniString(INI_SECTION_TIMER, "CLOCK_TIMEOUT_ACTION", timeoutActionStr, config_path);
     WriteIniString(INI_SECTION_TIMER, "CLOCK_TIMEOUT_FILE", CLOCK_TIMEOUT_FILE_PATH, config_path);
@@ -3337,6 +3345,7 @@ void WriteConfigKeyValue(const char* key, const char* value) {
            strncmp(key, "CLOCK_SHOW_SECONDS", 18) == 0 ||
            strncmp(key, "CLOCK_TIME_FORMAT", 17) == 0 ||
            strncmp(key, "CLOCK_SHOW_MILLISECONDS", 23) == 0 ||
+           strncmp(key, "CLOCK_TICK_SOUND", 16) == 0 ||
            strncmp(key, "CLOCK_TIME_OPTIONS", 18) == 0 ||
            strncmp(key, "STARTUP_MODE", 12) == 0 ||
            strncmp(key, "CLOCK_TIMEOUT_TEXT", 18) == 0 ||
@@ -3600,6 +3609,15 @@ void WriteConfigTimeFormat(TimeFormatType format) {
 void WriteConfigShowMilliseconds(BOOL showMilliseconds) {
     CLOCK_SHOW_MILLISECONDS = showMilliseconds;
     WriteConfigKeyValue("CLOCK_SHOW_MILLISECONDS", showMilliseconds ? "TRUE" : "FALSE");
+}
+
+/**
+ * @brief Write tick-tock sound setting to config file
+ * @param enable TRUE to enable tick-tock sound, FALSE to disable
+ */
+void WriteConfigTickSound(BOOL enable) {
+    CLOCK_TICK_SOUND = enable;
+    WriteConfigKeyValue("CLOCK_TICK_SOUND", enable ? "TRUE" : "FALSE");
 }
 
 /**

--- a/src/timer_events.c
+++ b/src/timer_events.c
@@ -84,6 +84,19 @@ extern void ShowCountUp(HWND hwnd);
 
 extern void StopNotificationSound(void);
 
+/** @brief Toggle state for alternating tick and tock tones */
+static BOOL s_tickToggle = FALSE;
+
+/**
+ * @brief Play a short tick-tock beep using Windows Beep
+ * Alternates frequencies to mimic a mechanical clock
+ */
+static void PlayTickTockSound(void) {
+    DWORD freq = s_tickToggle ? 750 : 1000;
+    s_tickToggle = !s_tickToggle;
+    Beep(freq, 50);
+}
+
 /**
  * @brief Convert UTF-8 string to Windows wide character string
  * @param utf8String Input UTF-8 encoded string
@@ -269,7 +282,14 @@ BOOL HandleTimerEvent(HWND hwnd, WPARAM wp) {
         if (ms_accumulator >= 1000) {
             int seconds_to_add = ms_accumulator / 1000;
             ms_accumulator %= 1000;  /** Keep remainder for next time */
-            
+
+            /** Play ticking sound for each elapsed second when enabled */
+            if (CLOCK_TICK_SOUND && !CLOCK_COUNT_UP) {
+                for (int i = 0; i < seconds_to_add && (countdown_elapsed_time + i) < CLOCK_TOTAL_TIME; i++) {
+                    PlayTickTockSound();
+                }
+            }
+
             /** Count-up mode: increment elapsed time by actual seconds */
             if (CLOCK_COUNT_UP) {
                 countup_elapsed_time += seconds_to_add;

--- a/src/tray_menu.c
+++ b/src/tray_menu.c
@@ -331,9 +331,13 @@ void ShowColorMenu(HWND hwnd) {
     AppendMenuW(hFormatMenu, MF_STRING | (CLOCK_SHOW_MILLISECONDS ? MF_CHECKED : MF_UNCHECKED),
                 CLOCK_IDM_TIME_FORMAT_SHOW_MILLISECONDS,
                 GetLocalizedString(L"显示毫秒", L"Show Milliseconds"));
-    
+
     AppendMenuW(hTimeOptionsMenu, MF_SEPARATOR, 0, NULL);
-    
+
+    AppendMenuW(hTimeOptionsMenu, MF_STRING | (CLOCK_TICK_SOUND ? MF_CHECKED : MF_UNCHECKED),
+                CLOCK_IDM_TICK_SOUND,
+                GetLocalizedString(L"滴答声", L"Tick Tock Sound"));
+
     AppendMenuW(hTimeOptionsMenu, MF_STRING | (CLOCK_WINDOW_TOPMOST ? MF_CHECKED : MF_UNCHECKED),
                 CLOCK_IDM_TOPMOST,
                 GetLocalizedString(L"置顶", L"Always on Top"));

--- a/src/window_procedure.c
+++ b/src/window_procedure.c
@@ -1336,6 +1336,11 @@ LRESULT CALLBACK WindowProcedure(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
                     InvalidateRect(hwnd, NULL, TRUE);
                     break;
                 }
+
+                case CLOCK_IDM_TICK_SOUND: {
+                    WriteConfigTickSound(!CLOCK_TICK_SOUND);
+                    break;
+                }
                 
                 /** Reset countdown timer to initial state */
                 case CLOCK_IDM_COUNTDOWN_RESET: {


### PR DESCRIPTION
## Summary
- document planned approach for adding tick‑tock audio
- allow enabling a tick‑tock beep through a new menu option and config setting
- play alternating tick‑tock beeps during countdown when enabled

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68be6970ad68832a8f12ee6514f10381